### PR TITLE
added awaiting refresh token callback

### DIFF
--- a/src/Hubstaff.ts
+++ b/src/Hubstaff.ts
@@ -79,7 +79,7 @@ class Hubstaff {
         );
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
-        this.refreshCallback(this.accessToken, this.refreshToken);
+        await this.refreshCallback(this.accessToken, this.refreshToken);
         this.api = axios.create({
           baseURL: "https://api.hubstaff.com/v2",
           headers: {


### PR DESCRIPTION
Currently, we don't have the ability to execute some async operations in refreshCallback. The change fixes this.